### PR TITLE
Adds reference to github-reference repo

### DIFF
--- a/new-developer-checklist.md
+++ b/new-developer-checklist.md
@@ -85,7 +85,7 @@ but GitHub has become the gathering place for the Open Source community.
 
 ### Register
 
-If you don't already have a GitHub account, get one today!
+If you don't already have a GitHub account, [get one today](https://github.com/dwyl/github-reference#how-to-sign-up)!
 (_try and match the username to the one you picked on Twitter for consistency_)
 
 > https://github.com/


### PR DESCRIPTION
Tiny change, but as I was looking through the changes here: https://github.com/dwyl/start-here/pull/89

I immediately thought of our github reference repo - it's mostly aimed at complete beginners but may be useful in some cases. Adding a quite link to it before I forget.