### PR TITLE
Removes bullet points / single numbered principle, replacing them with headings

### DIFF
--- a/manifesto.md
+++ b/manifesto.md
@@ -8,6 +8,7 @@ In *everything* we do, we follow [**The Golden Rule**](https://en.wikipedia.org/
 
 > "treat others as one would like others to treat oneself"
 
+<a name="never-waste-time"/>
 ### Your time should never be wasted.
  We believe everything *we* do should _Save. You. Time_ which you can then spend doing the things you love (you know, the ones you never have time for...).    
 
@@ -31,11 +32,12 @@ Whilst we don’t know _exactly_ what this is going to look like yet, we’re co
 
 ### _Full_ transparency
 We’re aware this may seem crazy, but we want to be fully transparent about everything we do, from [making decisions](#community) to finances :open_mouth: We’re an open book :book:
-<a name="OS"/>
 
+<a name="OS"/>
 ### Open source, always
 We don’t hide our code away. If you want to contribute to it, please do. If you want to use it as the starting point for something else, that’s fine too - just please give us some kudos for the hard work we’ve put in :relieved:
 
+<a name="latest-science"/>
 ### The latest science
 We’ll draw on the most interesting, important and relevant scientific research to help you improve your productivity.
 
@@ -45,11 +47,13 @@ We want to grow organically, at the right pace for us and to be flexible enough 
 ### Simple API
 The most easy-to-use API means you can quickly integrate the _time app_ features into your own websites, apps and internal flows. If it makes you more productive, we’re [happy for you to use it](#OS)
 
+<a name="people-not-users"/>
 ### We do not have users, [we have _people_](https://github.com/ideaq/time/issues/33).
 
+<a name="loyalty-first"/>
 ### Reward loyalty, not sign ups
 If we're giving out puppies, we're giving them to the people who've been with us from the start. [We're _**not**_ giving them out to new people and charging existing people for the privilege](https://twitter.com/iteles/status/561589203272994818).
-<a name="noForcedUpdates"/>
 
+<a name="no-forced-updates"/>
 ### No forced updates
 I hate it when I love the way an app is now and then it forces me to update to a new version where they have ruined the experience by trying to get the app to do too much and bloated the UI. _Don't you?_ Our plan is to keep things modular enough that if you :heart: the way the app looks now, you can keep it just the way you want it but still access new features.

--- a/manifesto.md
+++ b/manifesto.md
@@ -14,7 +14,7 @@ In *everything* we do, we follow [**The Golden Rule**](https://en.wikipedia.org/
 
  <a name="simple"/>
 ### Keep it simple
- Poor planning and lack of modularity are the mothers of bloated apps. If how you go about doing something in the that app isn’t _obvious_, then it needs to be changed.
+ Poor planning and lack of modularity are the mothers of bloated apps. If how you go about doing something in the app isn’t _obvious_, then it needs to be changed.
 
 ### Community driven
 We have a lot of ideas for great ways the app can help you track your time, become more productive and more organised (based on the latest science), but we don’t want to [give you something you don’t want](#noForcedUpdates) so we’ll be asking you for your thoughts before we start working on new features. Everything we put out into the world will be voted on by you, the people who use our app. And we hope that once you start using it, [you’ll have some great ideas](http://web.mit.edu/evhippel/www/democ1.htm) of things you’d like to see built into the app and we can vote on those as a community too.

--- a/manifesto.md
+++ b/manifesto.md
@@ -9,18 +9,16 @@ In *everything* we do, we follow [**The Golden Rule**](https://en.wikipedia.org/
 > "treat others as one would like others to treat oneself"
 
 ### Your time should never be wasted.
-
  We believe everything *we* do should _Save. You. Time_ which you can then spend doing the things you love (you know, the ones you never have time for...).    
-
 
  <a name="simple"/>
 ### Keep it simple
  Poor planning and lack of modularity are the mothers of bloated apps. If how you go about doing something in the that app isn’t _obvious_, then it needs to be changed.
-<a name="no-selling-data"/>
 
 ### Community driven
 We have a lot of ideas for great ways the app can help you track your time, become more productive and more organised (based on the latest science), but we don’t want to [give you something you don’t want](#noForcedUpdates) so we’ll be asking you for your thoughts before we start working on new features. Everything we put out into the world will be voted on by you, the people who use our app. And we hope that once you start using it, [you’ll have some great ideas](http://web.mit.edu/evhippel/www/democ1.htm) of things you’d like to see built into the app and we can vote on those as a community too.
 
+<a name="no-selling-data"/>
 ### Your data is yours
  Which means we don’t sell it. We [don’t use it to study you without your knowledge or consent](http://www.forbes.com/sites/kashmirhill/2014/06/28/facebook-manipulated-689003-users-emotions-for-science/). We don’t give it to your boss. It’s your information and you are in control of who sees any given portion of it and how it’s used ([simply and easily](#simple), not hidden behind a mass of complicated menus).
 <a name="community"/>

--- a/manifesto.md
+++ b/manifesto.md
@@ -17,29 +17,40 @@ In *everything* we do, we follow [**The Golden Rule**](https://en.wikipedia.org/
 1. **Keep it simple**. Poor planning and lack of modularity are the mothers of bloated apps. If how you go about doing something in the that app isn’t _obvious_, then it needs to be changed.
 <a name="no-selling-data"/>
 
-+ **Community driven**. We have a lot of ideas for great ways the app can help you track your time, become more productive and more organised (based on the latest science), but we don’t want to [give you something you don’t want](#noForcedUpdates) so we’ll be asking you for your thoughts before we start working on new features. Everything we put out into the world will be voted on by you, the people who use our app. And we hope that once you start using it, [you’ll have some great ideas](http://web.mit.edu/evhippel/www/democ1.htm) of things you’d like to see built into the app and we can vote on those as a community too.
+### Community driven
+We have a lot of ideas for great ways the app can help you track your time, become more productive and more organised (based on the latest science), but we don’t want to [give you something you don’t want](#noForcedUpdates) so we’ll be asking you for your thoughts before we start working on new features. Everything we put out into the world will be voted on by you, the people who use our app. And we hope that once you start using it, [you’ll have some great ideas](http://web.mit.edu/evhippel/www/democ1.htm) of things you’d like to see built into the app and we can vote on those as a community too.
 
-+ **Your data is yours**. Which means we don’t sell it. We [don’t use it to study you without your knowledge or consent](http://www.forbes.com/sites/kashmirhill/2014/06/28/facebook-manipulated-689003-users-emotions-for-science/). We don’t give it to your boss. It’s your information and you are in control of who sees any given portion of it and how it’s used ([simply and easily](#simple), not hidden behind a mass of complicated menus).
+### Your data is yours
+ Which means we don’t sell it. We [don’t use it to study you without your knowledge or consent](http://www.forbes.com/sites/kashmirhill/2014/06/28/facebook-manipulated-689003-users-emotions-for-science/). We don’t give it to your boss. It’s your information and you are in control of who sees any given portion of it and how it’s used ([simply and easily](#simple), not hidden behind a mass of complicated menus).
 <a name="community"/>
 
-+ **Environmental love**. No company should be anything short of carbon neutral. The fact that we exist will be positive for the environment, not a detriment.
+### Environmental love
+ No company should be anything short of carbon neutral. The fact that we exist will be positive for the environment, not a detriment.
 
-+ **Accessibility:** Whilst we don’t know _exactly_ what this is going to look like yet, we’re counting on our community of users to let us know exactly what they need from day 1.
+### Accessibility
+Whilst we don’t know _exactly_ what this is going to look like yet, we’re counting on our community of users to let us know exactly what they need from day 1.
 
-+ **_Full_ transparency**. We’re aware this may seem crazy, but we want to be fully transparent about everything we do, from [making decisions](#community) to finances :open_mouth: We’re an open book :book:
+### _Full_ transparency
+We’re aware this may seem crazy, but we want to be fully transparent about everything we do, from [making decisions](#community) to finances :open_mouth: We’re an open book :book:
 <a name="OS"/>
 
-+ **Open source, always.** We don’t hide our code away. If you want to contribute to it, please do. If you want to use it as the starting point for something else, that’s fine too - just please give us some kudos for the hard work we’ve put in :relieved:
+### Open source, always
+We don’t hide our code away. If you want to contribute to it, please do. If you want to use it as the starting point for something else, that’s fine too - just please give us some kudos for the hard work we’ve put in :relieved:
 
-+ **The latest science**. We’ll draw on the most interesting, important and relevant scientific research to help you improve your productivity.
+### The latest science
+We’ll draw on the most interesting, important and relevant scientific research to help you improve your productivity.
 
-+ **Revenue funded**. We want to grow organically, at the right pace for us and to be flexible enough to move in the direction the [community](#community) wants to take us.
+### Revenue funded
+We want to grow organically, at the right pace for us and to be flexible enough to move in the direction the [community](#community) wants to take us.
 
-+ **Simple API**. The most easy-to-use API means you can quickly integrate the _time app_ features into your own websites, apps and internal flows. If it makes you more productive, we’re [happy for you to use it](#OS)
+### Simple API
+The most easy-to-use API means you can quickly integrate the _time app_ features into your own websites, apps and internal flows. If it makes you more productive, we’re [happy for you to use it](#OS)
 
-+ **We do not have users, [we have _people_](https://github.com/ideaq/time/issues/33).**
+### We do not have users, [we have _people_](https://github.com/ideaq/time/issues/33).
 
-+ **Reward loyalty, not sign ups.** If we're giving out puppies, we're giving them to the people who've been with us from the start. [We're _**not**_ giving them out to new people and charging existing people for the privilege](https://twitter.com/iteles/status/561589203272994818).
+### Reward loyalty, not sign ups
+If we're giving out puppies, we're giving them to the people who've been with us from the start. [We're _**not**_ giving them out to new people and charging existing people for the privilege](https://twitter.com/iteles/status/561589203272994818).
 <a name="noForcedUpdates"/>
 
-+ **No forced updates.** I hate it when I love the way an app is now and then it forces me to update to a new version where they have ruined the experience by trying to get the app to do too much and bloated the UI. _Don't you?_ Our plan is to keep things modular enough that if you :heart: the way the app looks now, you can keep it just the way you want it but still access new features.
+### No forced updates
+I hate it when I love the way an app is now and then it forces me to update to a new version where they have ruined the experience by trying to get the app to do too much and bloated the UI. _Don't you?_ Our plan is to keep things modular enough that if you :heart: the way the app looks now, you can keep it just the way you want it but still access new features.

--- a/manifesto.md
+++ b/manifesto.md
@@ -14,7 +14,8 @@ In *everything* we do, we follow [**The Golden Rule**](https://en.wikipedia.org/
 
 
  <a name="simple"/>
-1. **Keep it simple**. Poor planning and lack of modularity are the mothers of bloated apps. If how you go about doing something in the that app isn’t _obvious_, then it needs to be changed.
+### Keep it simple
+ Poor planning and lack of modularity are the mothers of bloated apps. If how you go about doing something in the that app isn’t _obvious_, then it needs to be changed.
 <a name="no-selling-data"/>
 
 ### Community driven

--- a/manifesto.md
+++ b/manifesto.md
@@ -17,7 +17,7 @@ In *everything* we do, we follow [**The Golden Rule**](https://en.wikipedia.org/
  Poor planning and lack of modularity are the mothers of bloated apps. If how you go about doing something in the app isn’t _obvious_, then it needs to be changed.
 
 ### Community driven
-We have a lot of ideas for great ways the app can help you track your time, become more productive and more organised (based on the latest science), but we don’t want to [give you something you don’t want](#noForcedUpdates) so we’ll be asking you for your thoughts before we start working on new features. Everything we put out into the world will be voted on by you, the people who use our app. And we hope that once you start using it, [you’ll have some great ideas](http://web.mit.edu/evhippel/www/democ1.htm) of things you’d like to see built into the app and we can vote on those as a community too.
+We have a lot of ideas for great ways the app can help you track your time, become more productive and more organised (based on the [latest science](#latest-science)), but we don’t want to [give you something you don’t want](#no-forced-updates) so we’ll be asking you for your thoughts before we start working on new features. Everything we put out into the world will be voted on by you, the people who use our app. And we hope that once you start using it, [you’ll have some great ideas](http://web.mit.edu/evhippel/www/democ1.htm) of things you’d like to see built into the app and we can vote on those as a community too.
 
 <a name="no-selling-data"/>
 ### Your data is yours

--- a/manifesto.md
+++ b/manifesto.md
@@ -12,9 +12,9 @@ In *everything* we do, we follow [**The Golden Rule**](https://en.wikipedia.org/
 
  We believe everything *we* do should _Save. You. Time_ which you can then spend doing the things you love (you know, the ones you never have time for...).    
 
- 
+
  <a name="simple"/>
-1. **Keep it simple**. Poor planning and lack of modularity are the mothers of bloated apps. If how you go about doing something in the app isn’t _obvious_, then it needs to be changed.
+1. **Keep it simple**. Poor planning and lack of modularity are the mothers of bloated apps. If how you go about doing something in the that app isn’t _obvious_, then it needs to be changed.
 <a name="no-selling-data"/>
 
 + **Community driven**. We have a lot of ideas for great ways the app can help you track your time, become more productive and more organised (based on the latest science), but we don’t want to [give you something you don’t want](#noForcedUpdates) so we’ll be asking you for your thoughts before we start working on new features. Everything we put out into the world will be voted on by you, the people who use our app. And we hope that once you start using it, [you’ll have some great ideas](http://web.mit.edu/evhippel/www/democ1.htm) of things you’d like to see built into the app and we can vote on those as a community too.


### PR DESCRIPTION
- Changes the manifesto so that former bullet points for dwyl's principles are now headings
- Ensures that longer headings have shorter names for anchor links to them
- These changes were applied both to former unnumbered bullets as well as the single numbered point 'keep it simple' recognised in issue #96 

Issues fixed: #96, #12 