### PR TITLE
Adds 'no exit strategy' to the manifesto

### DIFF
--- a/manifesto.md
+++ b/manifesto.md
@@ -69,3 +69,7 @@ If we're giving out puppies, we're giving them to the people who've been with us
 
 ### No forced updates
 I hate it when I love the way an app is now and then it forces me to update to a new version where they have ruined the experience by trying to get the app to do too much and bloated the UI. _Don't you?_ Our plan is to keep things modular enough that if you :heart: the way the app looks now, you can keep it just the way you want it but still access new features.
+
+### No 'exit strategy'
+[@nelsonic](https://github.com/nelsonic) wrote an _excellent_ summary of why we
+have no plans to _sell_ the organisation to anyone and why that is important to us: https://github.com/dwyl/hq/issues/189 .


### PR DESCRIPTION
The manifesto needs reformulation and revision #80 , but in the meantime, I didn't want the eloquent note @nelsonic wrote on _why_ we have no 'exit strategy' to be lost. https://github.com/dwyl/hq/issues/189

I have therefore added this to the manifesto to ensure it is there ahead of the reformulation.

