### PR TITLE
Add link to Pro Git book

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ we suggest you check out the following:
 + Interactive Workshop: https://github.com/jlord/git-it-electron
 + [@NataliaLKB](https://github.com/NataliaLKB)'s Tutorial: https://github.com/NataliaLKB/learn-git-basics
 + [First Contributions](https://github.com/roshanjossey/first-contributions): A project to help you get started with contributing to open source projects
++ Pro Git Book: https://git-scm.com/book/en/v2
 
 ### Open Source
 


### PR DESCRIPTION
The Pro Git book is an excellent resource to learn git.

Reading chapter 1, 2 and 3 gives beginners most of the info needed to use git. Should that be mentioned in the text, or should we keep it simple and just link to the book?