### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# This document allows GitHub to identify Markdown as a language and add them to GitHub Repository's language statistics.
+# https://gist.github.com/TitanRGB/5c7d35afb0999bfc7a3e03adab99438b
+*.md linguist-detectable=true
+*.md linguist-documentation=false


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/75297777/183843225-cb75d7b6-385d-4a2e-98c1-7dc0061eecc5.png)

Since this repo only contains Markdown documents, why not let the language statistician recognize it?